### PR TITLE
Chore/upgrade examples

### DIFF
--- a/examples/counter/package.json
+++ b/examples/counter/package.json
@@ -22,15 +22,15 @@
   },
   "homepage": "https://github.com/motorcyclets/motorcycle#readme",
   "dependencies": {
-    "@motorcycle/dom": "15.0.0",
-    "@motorcycle/mostly-dom": "3.1.0",
-    "@motorcycle/run": "3.5.0",
-    "@motorcycle/stream": "1.6.0"
+    "@motorcycle/dom": "16.0.0",
+    "@motorcycle/mostly-dom": "4.0.0",
+    "@motorcycle/run": "4.0.0",
+    "@motorcycle/stream": "2.0.0"
   },
   "devDependencies": {
-    "@types/node": "8.0.25",
-    "ts-loader": "2.3.4",
-    "webpack": "3.5.5",
+    "@types/node": "8.0.28",
+    "ts-loader": "2.3.7",
+    "webpack": "3.5.6",
     "webpack-dev-server": "2.7.1"
   }
 }

--- a/examples/counter/yarn.lock
+++ b/examples/counter/yarn.lock
@@ -2,118 +2,85 @@
 # yarn lockfile v1
 
 
-"167@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/167/-/167-0.37.0.tgz#8cbe1589b2e9fa363eb7d128b3e46572c44a849b"
+"167@0.39.0":
+  version "0.39.0"
+  resolved "https://registry.yarnpkg.com/167/-/167-0.39.0.tgz#79638b8019aa92cf500eb43f6ed04eef65f8d987"
 
-"@most/core@0.11.2":
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/@most/core/-/core-0.11.2.tgz#6e3615fb4fc5a6a32cd35acb10a513a0e56df150"
+"@most/core@0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@most/core/-/core-0.13.0.tgz#ff1e7e08478514655230db6a1dbb8aca0fdcf882"
   dependencies:
-    "@most/disposable" "^0.11.0"
-    "@most/prelude" "^1.6.2"
-    "@most/scheduler" "^0.11.0"
-    "@most/types" "^0.10.0"
+    "@most/disposable" "^0.13.0"
+    "@most/prelude" "^1.6.4"
+    "@most/scheduler" "^0.13.0"
+    "@most/types" "^0.11.1"
 
-"@most/core@0.11.4":
-  version "0.11.4"
-  resolved "https://registry.yarnpkg.com/@most/core/-/core-0.11.4.tgz#324147de4ac86320313a3d9240b30c5fced72d1b"
+"@most/disposable@0.13.0", "@most/disposable@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@most/disposable/-/disposable-0.13.0.tgz#6007df024b29a07a7b171e4ee7edf736038ea5f5"
   dependencies:
-    "@most/disposable" "^0.11.0"
-    "@most/prelude" "^1.6.2"
-    "@most/scheduler" "^0.11.0"
-    "@most/types" "^0.10.0"
+    "@most/prelude" "^1.6.4"
+    "@most/types" "^0.11.1"
 
-"@most/disposable@0.11.0", "@most/disposable@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@most/disposable/-/disposable-0.11.0.tgz#ad9d0d160d932a6881785f363083a44d8400cef5"
+"@most/prelude@^1.6.0", "@most/prelude@^1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@most/prelude/-/prelude-1.6.4.tgz#254ab6e22c0d4e7cb19e6ec1c966b75f57317f25"
+
+"@most/scheduler@0.13.0", "@most/scheduler@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@most/scheduler/-/scheduler-0.13.0.tgz#d76f0713ed04df4c7c9250c16a9c966e89cd6248"
   dependencies:
-    "@most/prelude" "^1.6.2"
-    "@most/types" "^0.10.0"
+    "@most/prelude" "^1.6.4"
+    "@most/types" "^0.11.1"
 
-"@most/prelude@^1.6.0", "@most/prelude@^1.6.2":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@most/prelude/-/prelude-1.6.3.tgz#4eb453acb3251c47b92daa98d1652b704501c027"
+"@most/types@0.11.1", "@most/types@^0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@most/types/-/types-0.11.1.tgz#5e305e0e346c5b01f1ebdeec4c1dfa5b189b5f9d"
 
-"@most/scheduler@0.11.0", "@most/scheduler@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@most/scheduler/-/scheduler-0.11.0.tgz#0f67a0f097c9358e4308931e206c03a30f87faf4"
+"@motorcycle/dom@16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@motorcycle/dom/-/dom-16.0.0.tgz#15cc16771fa53b612acb24d6d57a465bc9c5e4c5"
   dependencies:
-    "@most/prelude" "^1.6.2"
-    "@most/types" "^0.10.0"
+    "167" "0.39.0"
+    "@motorcycle/stream" "2.0.0"
+    "@motorcycle/types" "2.0.0"
 
-"@most/types@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@most/types/-/types-0.10.0.tgz#5a60b581915349b210a13fed1563e9d06cba287f"
-
-"@motorcycle/dom@14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/dom/-/dom-14.0.0.tgz#dd9ca1a470e486de6573da95ddb77ec8432cce48"
+"@motorcycle/mostly-dom@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@motorcycle/mostly-dom/-/mostly-dom-4.0.0.tgz#7494399aff4ab54470597fb83a33a0c5872d6e12"
   dependencies:
-    "167" "0.37.0"
-    "@motorcycle/stream" "1.5.0"
-    "@motorcycle/types" "1.3.0"
+    "167" "0.39.0"
+    "@motorcycle/dom" "16.0.0"
+    "@motorcycle/stream" "2.0.0"
+    "@motorcycle/types" "2.0.0"
+    mostly-dom "4.3.0"
 
-"@motorcycle/dom@15.0.0":
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/dom/-/dom-15.0.0.tgz#e8ee0fc94900837f017a788594a414cafbdcaae1"
+"@motorcycle/run@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@motorcycle/run/-/run-4.0.0.tgz#30034346939ef8c38f3ac182ca28f997acaa31b3"
   dependencies:
-    "167" "0.37.0"
-    "@motorcycle/stream" "1.6.0"
-    "@motorcycle/types" "1.5.0"
+    "@motorcycle/stream" "2.0.0"
+    "@motorcycle/types" "2.0.0"
 
-"@motorcycle/mostly-dom@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/mostly-dom/-/mostly-dom-3.1.0.tgz#7a7e54d18029274342f4dd172dd714433bd9b90c"
+"@motorcycle/stream@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@motorcycle/stream/-/stream-2.0.0.tgz#dd44a14744e0f7f809b7e13f0b270f64add3e8be"
   dependencies:
-    "167" "0.37.0"
-    "@motorcycle/dom" "14.0.0"
-    "@motorcycle/stream" "1.6.0"
-    "@motorcycle/types" "1.5.0"
-    mostly-dom "4.0.0"
+    "167" "0.39.0"
+    "@most/core" "0.13.0"
+    "@most/disposable" "0.13.0"
+    "@most/scheduler" "0.13.0"
+    "@motorcycle/types" "2.0.0"
 
-"@motorcycle/run@3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/run/-/run-3.5.0.tgz#41fe8bcb983068132510b5850aabdcde6b2cf8e5"
+"@motorcycle/types@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@motorcycle/types/-/types-2.0.0.tgz#a4adc8ecff575076312659246786c7ae705006a3"
   dependencies:
-    "@motorcycle/stream" "1.6.0"
-    "@motorcycle/types" "1.5.0"
+    "@most/types" "0.11.1"
 
-"@motorcycle/stream@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/stream/-/stream-1.5.0.tgz#b1a10498ab02fbd91a4fe83544d3ab26cd1261d2"
-  dependencies:
-    "167" "0.37.0"
-    "@most/core" "0.11.2"
-    "@most/disposable" "0.11.0"
-    "@most/scheduler" "0.11.0"
-    "@motorcycle/types" "1.3.0"
-
-"@motorcycle/stream@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/stream/-/stream-1.6.0.tgz#ef2103414b85dcd3f329edff0884fce86ca684a5"
-  dependencies:
-    "167" "0.37.0"
-    "@most/core" "0.11.4"
-    "@most/disposable" "0.11.0"
-    "@most/scheduler" "0.11.0"
-    "@motorcycle/types" "1.5.0"
-
-"@motorcycle/types@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/types/-/types-1.3.0.tgz#3a895f6dd601171ea3310211328b8045badae22b"
-  dependencies:
-    "@most/types" "^0.10.0"
-
-"@motorcycle/types@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/types/-/types-1.5.0.tgz#c195204212f8ee59f25199fab9c7e17f3956dfdb"
-  dependencies:
-    "@most/types" "^0.10.0"
-
-"@types/node@8.0.25":
-  version "8.0.25"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.25.tgz#66ecaf4df93f5281b48427ee96fbcdfc4f0cdce1"
+"@types/node@8.0.28":
+  version "8.0.28"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.28.tgz#86206716f8d9251cf41692e384264cbd7058ad60"
 
 abbrev@1:
   version "1.1.0"
@@ -137,8 +104,8 @@ acorn@^4.0.3:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
 acorn@^5.0.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.1.tgz#53fe161111f912ab999ee887a90a0bc52822fd75"
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.2.tgz#911cb53e036807cf0fa778dc5d370fbd864246d7"
 
 ajv-keywords@^2.0.0:
   version "2.1.0"
@@ -365,14 +332,15 @@ brorand@^1.0.1:
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
 
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.0.6.tgz#5e7725dbdef1fd5930d4ebab48567ce451c48a0a"
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.0.8.tgz#c8fa3b1b7585bb7ba77c5560b60996ddec6d5309"
   dependencies:
-    buffer-xor "^1.0.2"
+    buffer-xor "^1.0.3"
     cipher-base "^1.0.0"
     create-hash "^1.1.0"
-    evp_bytestokey "^1.0.0"
+    evp_bytestokey "^1.0.3"
     inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 browserify-cipher@^1.0.0:
   version "1.0.0"
@@ -419,7 +387,7 @@ buffer-indexof@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-1.1.1.tgz#52fabcc6a606d1a00302802648ef68f639da268c"
 
-buffer-xor@^1.0.2:
+buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
 
@@ -592,8 +560,8 @@ content-disposition@0.5.2:
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
 
 content-type@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.2.tgz#b7d113aee7a8dd27bd21133c4dc2529df1721eed"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.3.tgz#da18ef2fb64ca6acc905cc72017d3f38185b91d1"
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -695,13 +663,24 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
-deep-equal@^1.0.1:
+deep-equal@^1.0.1, deep-equal@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
+
+define-properties@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
+  dependencies:
+    foreach "^2.0.5"
+    object-keys "^1.0.8"
+
+defined@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
 
 del@^3.0.0:
   version "3.0.0"
@@ -821,6 +800,24 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
+es-abstract@^1.5.0:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.8.2.tgz#25103263dc4decbda60e0c737ca32313518027ee"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
+es-to-primitive@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
+  dependencies:
+    is-callable "^1.1.1"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.1"
+
 es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
   version "0.10.30"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.30.tgz#7141a16836697dbabfaaaeee41495ce29f52c939"
@@ -926,9 +923,9 @@ eventsource@0.1.6:
   dependencies:
     original ">=0.0.5"
 
-evp_bytestokey@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.2.tgz#f66bb88ecd57f71a766821e20283ea38c68bf80a"
+evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
@@ -1059,6 +1056,12 @@ find-up@^2.0.0:
   dependencies:
     locate-path "^2.0.0"
 
+for-each@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.2.tgz#2c40450b9348e97f281322593ba96704b9abd4d4"
+  dependencies:
+    is-function "~1.0.0"
+
 for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -1068,6 +1071,10 @@ for-own@^0.1.4:
   resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
   dependencies:
     for-in "^1.0.1"
+
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -1082,8 +1089,8 @@ form-data@~2.1.1:
     mime-types "^2.1.12"
 
 forwarded@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.0.tgz#19ef9874c4ae1c297bcf078fde63a09b66a84363"
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.1.tgz#8a4e30c640b05395399a3549c730257728048961"
 
 fresh@0.5.0:
   version "0.5.0"
@@ -1116,6 +1123,10 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     inherits "~2.0.0"
     mkdirp ">=0.5 0"
     rimraf "2"
+
+function-bind@^1.0.2, function-bind@^1.1.1, function-bind@~1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -1161,7 +1172,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^7.0.3, glob@^7.0.5:
+glob@^7.0.3, glob@^7.0.5, glob@~7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -1212,6 +1223,12 @@ has-flag@^2.0.0:
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+
+has@^1.0.1, has@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
+  dependencies:
+    function-bind "^1.0.2"
 
 hash-base@^2.0.0:
   version "2.0.2"
@@ -1387,6 +1404,14 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
+is-callable@^1.1.1, is-callable@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
@@ -1424,6 +1449,10 @@ is-fullwidth-code-point@^1.0.0:
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+
+is-function@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
 
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
@@ -1473,9 +1502,19 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  dependencies:
+    has "^1.0.1"
+
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-symbol@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -1712,19 +1751,15 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-"mime-db@>= 1.29.0 < 2":
+"mime-db@>= 1.29.0 < 2", mime-db@~1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
 
-mime-db@~1.29.0:
-  version "1.29.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.29.0.tgz#48d26d235589651704ac5916ca06001914266878"
-
 mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.7:
-  version "2.1.16"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.16.tgz#2b858a52e5ecd516db897ac2be87487830698e23"
+  version "2.1.17"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
   dependencies:
-    mime-db "~1.29.0"
+    mime-db "~1.30.0"
 
 mime@1.3.4:
   version "1.3.4"
@@ -1756,7 +1791,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.3, minimist@^1.2.0, minimist@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -1766,9 +1801,9 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@~0.5.0:
   dependencies:
     minimist "0.0.8"
 
-mostly-dom@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/mostly-dom/-/mostly-dom-4.0.0.tgz#1fff07323f03b01def2cbe6092cc94d99729049d"
+mostly-dom@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/mostly-dom/-/mostly-dom-4.3.0.tgz#6ff3188240923ae4112b68768b7b7d11661d718a"
   dependencies:
     "@most/prelude" "^1.6.0"
 
@@ -1788,8 +1823,8 @@ multicast-dns@^6.0.1:
     thunky "^0.1.0"
 
 nan@^2.3.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
 
 negotiator@0.6.1:
   version "0.6.1"
@@ -1828,8 +1863,8 @@ node-libs-browser@^2.0.0:
     vm-browserify "0.0.4"
 
 node-pre-gyp@^0.6.36:
-  version "0.6.36"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz#db604112cb74e0d477554e9b505b17abddfab786"
+  version "0.6.37"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.37.tgz#3c872b236b2e266e4140578fe1ee88f693323a05"
   dependencies:
     mkdirp "^0.5.1"
     nopt "^4.0.1"
@@ -1838,6 +1873,7 @@ node-pre-gyp@^0.6.36:
     request "^2.81.0"
     rimraf "^2.6.1"
     semver "^5.3.0"
+    tape "^4.6.3"
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
@@ -1889,6 +1925,14 @@ oauth-sign@~0.8.1:
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+object-inspect@~1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.3.0.tgz#5b1eb8e6742e2ee83342a637034d844928ba2f6d"
+
+object-keys@^1.0.8:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -2011,8 +2055,8 @@ parse-json@^2.2.0:
     error-ex "^1.2.0"
 
 parseurl@~1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
 
 path-browserify@0.0.0:
   version "0.0.0"
@@ -2040,6 +2084,10 @@ path-key@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
+path-parse@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
@@ -2059,8 +2107,8 @@ path-type@^2.0.0:
     pify "^2.0.0"
 
 pbkdf2@^3.0.3:
-  version "3.0.13"
-  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.13.tgz#c37d295531e786b1da3e3eadc840426accb0ae25"
+  version "3.0.14"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.14.tgz#a35e13c64799b06ce15320f459c230e68e73bade"
   dependencies:
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
@@ -2252,11 +2300,10 @@ redent@^1.0.0:
     strip-indent "^1.0.1"
 
 regex-cache@^0.4.2:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.3.tgz#9b1a6c35d4d0dfcef5711ae651e8e9d3d7114145"
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
   dependencies:
     is-equal-shallow "^0.1.3"
-    is-primitive "^2.0.0"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -2315,6 +2362,18 @@ requires-port@1.0.x, requires-port@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
+resolve@~1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
+  dependencies:
+    path-parse "^1.0.5"
+
+resumer@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/resumer/-/resumer-0.0.0.tgz#f1e8f461e4064ba39e82af3cdc2a8c893d076759"
+  dependencies:
+    through "~2.3.4"
+
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
@@ -2322,8 +2381,8 @@ right-align@^0.1.1:
     align-text "^0.1.1"
 
 rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
     glob "^7.0.5"
 
@@ -2546,6 +2605,14 @@ string-width@^2.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string.prototype.trim@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.5.0"
+    function-bind "^1.0.2"
+
 string_decoder@^0.10.25:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -2603,14 +2670,32 @@ supports-color@^3.1.1:
     has-flag "^1.0.0"
 
 supports-color@^4.0.0, supports-color@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.2.1.tgz#65a4bb2631e90e02420dba5554c375a4754bb836"
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
   dependencies:
     has-flag "^2.0.0"
 
 tapable@^0.2.7:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.8.tgz#99372a5c999bf2df160afc0d74bed4f47948cd22"
+
+tape@^4.6.3:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/tape/-/tape-4.8.0.tgz#f6a9fec41cc50a1de50fa33603ab580991f6068e"
+  dependencies:
+    deep-equal "~1.0.1"
+    defined "~1.0.0"
+    for-each "~0.3.2"
+    function-bind "~1.1.0"
+    glob "~7.1.2"
+    has "~1.0.1"
+    inherits "~2.0.3"
+    minimist "~1.2.0"
+    object-inspect "~1.3.0"
+    resolve "~1.4.0"
+    resumer "~0.0.0"
+    string.prototype.trim "~1.1.2"
+    through "~2.3.8"
 
 tar-pack@^3.4.0:
   version "3.4.0"
@@ -2632,6 +2717,10 @@ tar@^2.2.1:
     block-stream "*"
     fstream "^1.0.2"
     inherits "2"
+
+through@~2.3.4, through@~2.3.8:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
 thunky@^0.1.0:
   version "0.1.0"
@@ -2661,9 +2750,9 @@ trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
 
-ts-loader@2.3.4:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-2.3.4.tgz#904f82f6812406f3f073c1c114eea2759e27f80a"
+ts-loader@2.3.7:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-2.3.7.tgz#a9028ced473bee12f28a75f9c5b139979d33f2fc"
   dependencies:
     chalk "^2.0.1"
     enhanced-resolve "^3.0.0"
@@ -2847,9 +2936,9 @@ webpack-sources@^1.0.1:
     source-list-map "^2.0.0"
     source-map "~0.5.3"
 
-webpack@3.5.5:
-  version "3.5.5"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.5.5.tgz#3226f09fc8b3e435ff781e7af34f82b68b26996c"
+webpack@3.5.6:
+  version "3.5.6"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.5.6.tgz#a492fb6c1ed7f573816f90e00c8fbb5a20cc5c36"
   dependencies:
     acorn "^5.0.0"
     acorn-dynamic-import "^2.0.0"
@@ -2881,8 +2970,8 @@ websocket-driver@>=0.5.1:
     websocket-extensions ">=0.1.1"
 
 websocket-extensions@>=0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.1.tgz#76899499c184b6ef754377c2dbb0cd6cb55d29e7"
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.2.tgz#0e18781de629a18308ce1481650f67ffa2693a5d"
 
 which-module@^1.0.0:
   version "1.0.0"

--- a/examples/sokoban/package.json
+++ b/examples/sokoban/package.json
@@ -22,16 +22,16 @@
   },
   "homepage": "https://github.com/motorcyclets/motorcycle#readme",
   "dependencies": {
-    "167": "0.38.0",
-    "@motorcycle/dom": "15.1.0",
-    "@motorcycle/mostly-dom": "3.2.0",
-    "@motorcycle/run": "3.6.0",
-    "@motorcycle/stream": "1.6.0"
+    "167": "0.39.0",
+    "@motorcycle/dom": "16.0.0",
+    "@motorcycle/mostly-dom": "4.0.0",
+    "@motorcycle/run": "4.0.0",
+    "@motorcycle/stream": "2.0.0"
   },
   "devDependencies": {
-    "@types/node": "8.0.25",
-    "ts-loader": "2.3.4",
-    "webpack": "3.5.5",
+    "@types/node": "8.0.28",
+    "ts-loader": "2.3.7",
+    "webpack": "3.5.6",
     "webpack-dev-server": "2.7.1"
   }
 }

--- a/examples/sokoban/yarn.lock
+++ b/examples/sokoban/yarn.lock
@@ -2,132 +2,85 @@
 # yarn lockfile v1
 
 
-"167@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/167/-/167-0.37.0.tgz#8cbe1589b2e9fa363eb7d128b3e46572c44a849b"
+"167@0.39.0":
+  version "0.39.0"
+  resolved "https://registry.yarnpkg.com/167/-/167-0.39.0.tgz#79638b8019aa92cf500eb43f6ed04eef65f8d987"
 
-"167@0.38.0":
-  version "0.38.0"
-  resolved "https://registry.yarnpkg.com/167/-/167-0.38.0.tgz#87c60dad6df6e4560a0a058db558c9c89c45c01a"
-
-"@most/core@0.11.4":
-  version "0.11.4"
-  resolved "https://registry.yarnpkg.com/@most/core/-/core-0.11.4.tgz#324147de4ac86320313a3d9240b30c5fced72d1b"
+"@most/core@0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@most/core/-/core-0.13.0.tgz#ff1e7e08478514655230db6a1dbb8aca0fdcf882"
   dependencies:
-    "@most/disposable" "^0.11.0"
-    "@most/prelude" "^1.6.2"
-    "@most/scheduler" "^0.11.0"
-    "@most/types" "^0.10.0"
+    "@most/disposable" "^0.13.0"
+    "@most/prelude" "^1.6.4"
+    "@most/scheduler" "^0.13.0"
+    "@most/types" "^0.11.1"
 
-"@most/core@0.12.1":
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/@most/core/-/core-0.12.1.tgz#1895b9b02566b2fe2213997a397af03802d3f78c"
+"@most/disposable@0.13.0", "@most/disposable@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@most/disposable/-/disposable-0.13.0.tgz#6007df024b29a07a7b171e4ee7edf736038ea5f5"
   dependencies:
-    "@most/disposable" "^0.12.0"
-    "@most/prelude" "^1.6.3"
-    "@most/scheduler" "^0.12.0"
-    "@most/types" "^0.11.0"
+    "@most/prelude" "^1.6.4"
+    "@most/types" "^0.11.1"
 
-"@most/disposable@0.11.0", "@most/disposable@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@most/disposable/-/disposable-0.11.0.tgz#ad9d0d160d932a6881785f363083a44d8400cef5"
-  dependencies:
-    "@most/prelude" "^1.6.2"
-    "@most/types" "^0.10.0"
-
-"@most/disposable@0.12.0", "@most/disposable@^0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@most/disposable/-/disposable-0.12.0.tgz#aaf3fe59eef9b951b43265abbbaac25548b64ccf"
-  dependencies:
-    "@most/prelude" "^1.6.3"
-    "@most/types" "^0.11.0"
-
-"@most/prelude@^1.6.0", "@most/prelude@^1.6.2", "@most/prelude@^1.6.3":
+"@most/prelude@^1.6.0", "@most/prelude@^1.6.4":
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/@most/prelude/-/prelude-1.6.4.tgz#254ab6e22c0d4e7cb19e6ec1c966b75f57317f25"
 
-"@most/scheduler@0.11.0", "@most/scheduler@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@most/scheduler/-/scheduler-0.11.0.tgz#0f67a0f097c9358e4308931e206c03a30f87faf4"
+"@most/scheduler@0.13.0", "@most/scheduler@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@most/scheduler/-/scheduler-0.13.0.tgz#d76f0713ed04df4c7c9250c16a9c966e89cd6248"
   dependencies:
-    "@most/prelude" "^1.6.2"
-    "@most/types" "^0.10.0"
+    "@most/prelude" "^1.6.4"
+    "@most/types" "^0.11.1"
 
-"@most/scheduler@0.12.0", "@most/scheduler@^0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@most/scheduler/-/scheduler-0.12.0.tgz#149b1e40194379a96dc4f10f321010c463feeac8"
+"@most/types@0.11.1", "@most/types@^0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@most/types/-/types-0.11.1.tgz#5e305e0e346c5b01f1ebdeec4c1dfa5b189b5f9d"
+
+"@motorcycle/dom@16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@motorcycle/dom/-/dom-16.0.0.tgz#15cc16771fa53b612acb24d6d57a465bc9c5e4c5"
   dependencies:
-    "@most/prelude" "^1.6.3"
-    "@most/types" "^0.11.0"
+    "167" "0.39.0"
+    "@motorcycle/stream" "2.0.0"
+    "@motorcycle/types" "2.0.0"
 
-"@most/types@0.11.0", "@most/types@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@most/types/-/types-0.11.0.tgz#39ca6c156163a65ba754ca8c7ebdb309d21197c6"
-
-"@most/types@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@most/types/-/types-0.10.0.tgz#5a60b581915349b210a13fed1563e9d06cba287f"
-
-"@motorcycle/dom@15.1.0":
-  version "15.1.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/dom/-/dom-15.1.0.tgz#983f2081caa195b611ede3c9ab64df3bc3f187e4"
+"@motorcycle/mostly-dom@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@motorcycle/mostly-dom/-/mostly-dom-4.0.0.tgz#7494399aff4ab54470597fb83a33a0c5872d6e12"
   dependencies:
-    "167" "0.37.0"
-    "@motorcycle/stream" "1.7.0"
-    "@motorcycle/types" "1.6.0"
+    "167" "0.39.0"
+    "@motorcycle/dom" "16.0.0"
+    "@motorcycle/stream" "2.0.0"
+    "@motorcycle/types" "2.0.0"
+    mostly-dom "4.3.0"
 
-"@motorcycle/mostly-dom@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/mostly-dom/-/mostly-dom-3.2.0.tgz#b950556da946a53bc68793d1189fd94b92639e88"
+"@motorcycle/run@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@motorcycle/run/-/run-4.0.0.tgz#30034346939ef8c38f3ac182ca28f997acaa31b3"
   dependencies:
-    "167" "0.37.0"
-    "@motorcycle/dom" "15.1.0"
-    "@motorcycle/stream" "1.7.0"
-    "@motorcycle/types" "1.6.0"
-    mostly-dom "4.2.0"
+    "@motorcycle/stream" "2.0.0"
+    "@motorcycle/types" "2.0.0"
 
-"@motorcycle/run@3.6.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/run/-/run-3.6.0.tgz#9716da9361ad06b74543a3695009148356770619"
+"@motorcycle/stream@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@motorcycle/stream/-/stream-2.0.0.tgz#dd44a14744e0f7f809b7e13f0b270f64add3e8be"
   dependencies:
-    "@motorcycle/stream" "1.7.0"
-    "@motorcycle/types" "1.6.0"
+    "167" "0.39.0"
+    "@most/core" "0.13.0"
+    "@most/disposable" "0.13.0"
+    "@most/scheduler" "0.13.0"
+    "@motorcycle/types" "2.0.0"
 
-"@motorcycle/stream@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/stream/-/stream-1.6.0.tgz#ef2103414b85dcd3f329edff0884fce86ca684a5"
+"@motorcycle/types@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@motorcycle/types/-/types-2.0.0.tgz#a4adc8ecff575076312659246786c7ae705006a3"
   dependencies:
-    "167" "0.37.0"
-    "@most/core" "0.11.4"
-    "@most/disposable" "0.11.0"
-    "@most/scheduler" "0.11.0"
-    "@motorcycle/types" "1.5.0"
+    "@most/types" "0.11.1"
 
-"@motorcycle/stream@1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/stream/-/stream-1.7.0.tgz#0dddf150e7bb89d6542de1391c6abf4568225f93"
-  dependencies:
-    "167" "0.37.0"
-    "@most/core" "0.12.1"
-    "@most/disposable" "0.12.0"
-    "@most/scheduler" "0.12.0"
-    "@motorcycle/types" "1.6.0"
-
-"@motorcycle/types@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/types/-/types-1.5.0.tgz#c195204212f8ee59f25199fab9c7e17f3956dfdb"
-  dependencies:
-    "@most/types" "^0.10.0"
-
-"@motorcycle/types@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/types/-/types-1.6.0.tgz#d8f43631cc67529a65411a42f156c087a8d95f95"
-  dependencies:
-    "@most/types" "0.11.0"
-
-"@types/node@8.0.25":
-  version "8.0.25"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.25.tgz#66ecaf4df93f5281b48427ee96fbcdfc4f0cdce1"
+"@types/node@8.0.28":
+  version "8.0.28"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.28.tgz#86206716f8d9251cf41692e384264cbd7058ad60"
 
 abbrev@1:
   version "1.1.0"
@@ -607,8 +560,8 @@ content-disposition@0.5.2:
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
 
 content-type@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.2.tgz#b7d113aee7a8dd27bd21133c4dc2529df1721eed"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.3.tgz#da18ef2fb64ca6acc905cc72017d3f38185b91d1"
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -1136,8 +1089,8 @@ form-data@~2.1.1:
     mime-types "^2.1.12"
 
 forwarded@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.0.tgz#19ef9874c4ae1c297bcf078fde63a09b66a84363"
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.1.tgz#8a4e30c640b05395399a3549c730257728048961"
 
 fresh@0.5.0:
   version "0.5.0"
@@ -1848,9 +1801,9 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@~0.5.0:
   dependencies:
     minimist "0.0.8"
 
-mostly-dom@4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/mostly-dom/-/mostly-dom-4.2.0.tgz#1a0bc40dd4b9136285799d4aad1d8102e53ca0d2"
+mostly-dom@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/mostly-dom/-/mostly-dom-4.3.0.tgz#6ff3188240923ae4112b68768b7b7d11661d718a"
   dependencies:
     "@most/prelude" "^1.6.0"
 
@@ -2102,8 +2055,8 @@ parse-json@^2.2.0:
     error-ex "^1.2.0"
 
 parseurl@~1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
 
 path-browserify@0.0.0:
   version "0.0.0"
@@ -2154,8 +2107,8 @@ path-type@^2.0.0:
     pify "^2.0.0"
 
 pbkdf2@^3.0.3:
-  version "3.0.13"
-  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.13.tgz#c37d295531e786b1da3e3eadc840426accb0ae25"
+  version "3.0.14"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.14.tgz#a35e13c64799b06ce15320f459c230e68e73bade"
   dependencies:
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
@@ -2428,8 +2381,8 @@ right-align@^0.1.1:
     align-text "^0.1.1"
 
 rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
     glob "^7.0.5"
 
@@ -2797,9 +2750,9 @@ trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
 
-ts-loader@2.3.4:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-2.3.4.tgz#904f82f6812406f3f073c1c114eea2759e27f80a"
+ts-loader@2.3.7:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-2.3.7.tgz#a9028ced473bee12f28a75f9c5b139979d33f2fc"
   dependencies:
     chalk "^2.0.1"
     enhanced-resolve "^3.0.0"
@@ -2983,9 +2936,9 @@ webpack-sources@^1.0.1:
     source-list-map "^2.0.0"
     source-map "~0.5.3"
 
-webpack@3.5.5:
-  version "3.5.5"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.5.5.tgz#3226f09fc8b3e435ff781e7af34f82b68b26996c"
+webpack@3.5.6:
+  version "3.5.6"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.5.6.tgz#a492fb6c1ed7f573816f90e00c8fbb5a20cc5c36"
   dependencies:
     acorn "^5.0.0"
     acorn-dynamic-import "^2.0.0"
@@ -3017,8 +2970,8 @@ websocket-driver@>=0.5.1:
     websocket-extensions ">=0.1.1"
 
 websocket-extensions@>=0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.1.tgz#76899499c184b6ef754377c2dbb0cd6cb55d29e7"
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.2.tgz#0e18781de629a18308ce1481650f67ffa2693a5d"
 
 which-module@^1.0.0:
   version "1.0.0"

--- a/examples/traffic-light/package.json
+++ b/examples/traffic-light/package.json
@@ -22,16 +22,16 @@
   },
   "homepage": "https://github.com/motorcyclets/motorcycle#readme",
   "dependencies": {
-    "@motorcycle/dom": "15.0.0",
-    "@motorcycle/mostly-dom": "3.1.0",
-    "@motorcycle/run": "3.5.0",
-    "@motorcycle/stream": "1.6.0"
+    "@motorcycle/dom": "16.0.0",
+    "@motorcycle/mostly-dom": "4.0.0",
+    "@motorcycle/run": "4.0.0",
+    "@motorcycle/stream": "2.0.0"
   },
   "devDependencies": {
-    "@motorcycle/test": "1.5.0",
-    "@types/node": "8.0.25",
-    "ts-loader": "2.3.4",
-    "webpack": "3.5.5",
+    "@motorcycle/test": "2.0.0",
+    "@types/node": "8.0.28",
+    "ts-loader": "2.3.7",
+    "webpack": "3.5.6",
     "webpack-dev-server": "2.7.1"
   }
 }

--- a/examples/traffic-light/yarn.lock
+++ b/examples/traffic-light/yarn.lock
@@ -2,126 +2,93 @@
 # yarn lockfile v1
 
 
-"167@0.37.0":
-  version "0.37.0"
-  resolved "https://registry.yarnpkg.com/167/-/167-0.37.0.tgz#8cbe1589b2e9fa363eb7d128b3e46572c44a849b"
+"167@0.39.0":
+  version "0.39.0"
+  resolved "https://registry.yarnpkg.com/167/-/167-0.39.0.tgz#79638b8019aa92cf500eb43f6ed04eef65f8d987"
 
-"@most/core@0.11.2":
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/@most/core/-/core-0.11.2.tgz#6e3615fb4fc5a6a32cd35acb10a513a0e56df150"
+"@most/core@0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@most/core/-/core-0.13.0.tgz#ff1e7e08478514655230db6a1dbb8aca0fdcf882"
   dependencies:
-    "@most/disposable" "^0.11.0"
-    "@most/prelude" "^1.6.2"
-    "@most/scheduler" "^0.11.0"
-    "@most/types" "^0.10.0"
+    "@most/disposable" "^0.13.0"
+    "@most/prelude" "^1.6.4"
+    "@most/scheduler" "^0.13.0"
+    "@most/types" "^0.11.1"
 
-"@most/core@0.11.4":
-  version "0.11.4"
-  resolved "https://registry.yarnpkg.com/@most/core/-/core-0.11.4.tgz#324147de4ac86320313a3d9240b30c5fced72d1b"
+"@most/disposable@0.13.0", "@most/disposable@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@most/disposable/-/disposable-0.13.0.tgz#6007df024b29a07a7b171e4ee7edf736038ea5f5"
   dependencies:
-    "@most/disposable" "^0.11.0"
-    "@most/prelude" "^1.6.2"
-    "@most/scheduler" "^0.11.0"
-    "@most/types" "^0.10.0"
+    "@most/prelude" "^1.6.4"
+    "@most/types" "^0.11.1"
 
-"@most/disposable@0.11.0", "@most/disposable@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@most/disposable/-/disposable-0.11.0.tgz#ad9d0d160d932a6881785f363083a44d8400cef5"
+"@most/prelude@^1.6.0", "@most/prelude@^1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@most/prelude/-/prelude-1.6.4.tgz#254ab6e22c0d4e7cb19e6ec1c966b75f57317f25"
+
+"@most/scheduler@0.13.0", "@most/scheduler@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/@most/scheduler/-/scheduler-0.13.0.tgz#d76f0713ed04df4c7c9250c16a9c966e89cd6248"
   dependencies:
-    "@most/prelude" "^1.6.2"
-    "@most/types" "^0.10.0"
+    "@most/prelude" "^1.6.4"
+    "@most/types" "^0.11.1"
 
-"@most/prelude@^1.6.0", "@most/prelude@^1.6.2":
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/@most/prelude/-/prelude-1.6.3.tgz#4eb453acb3251c47b92daa98d1652b704501c027"
+"@most/types@0.11.1", "@most/types@^0.11.1":
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/@most/types/-/types-0.11.1.tgz#5e305e0e346c5b01f1ebdeec4c1dfa5b189b5f9d"
 
-"@most/scheduler@0.11.0", "@most/scheduler@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@most/scheduler/-/scheduler-0.11.0.tgz#0f67a0f097c9358e4308931e206c03a30f87faf4"
+"@motorcycle/dom@16.0.0":
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/@motorcycle/dom/-/dom-16.0.0.tgz#15cc16771fa53b612acb24d6d57a465bc9c5e4c5"
   dependencies:
-    "@most/prelude" "^1.6.2"
-    "@most/types" "^0.10.0"
+    "167" "0.39.0"
+    "@motorcycle/stream" "2.0.0"
+    "@motorcycle/types" "2.0.0"
 
-"@most/types@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@most/types/-/types-0.10.0.tgz#5a60b581915349b210a13fed1563e9d06cba287f"
-
-"@motorcycle/dom@14.0.0":
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/dom/-/dom-14.0.0.tgz#dd9ca1a470e486de6573da95ddb77ec8432cce48"
+"@motorcycle/mostly-dom@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@motorcycle/mostly-dom/-/mostly-dom-4.0.0.tgz#7494399aff4ab54470597fb83a33a0c5872d6e12"
   dependencies:
-    "167" "0.37.0"
-    "@motorcycle/stream" "1.5.0"
-    "@motorcycle/types" "1.3.0"
+    "167" "0.39.0"
+    "@motorcycle/dom" "16.0.0"
+    "@motorcycle/stream" "2.0.0"
+    "@motorcycle/types" "2.0.0"
+    mostly-dom "4.3.0"
 
-"@motorcycle/dom@15.0.0":
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/dom/-/dom-15.0.0.tgz#e8ee0fc94900837f017a788594a414cafbdcaae1"
+"@motorcycle/run@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@motorcycle/run/-/run-4.0.0.tgz#30034346939ef8c38f3ac182ca28f997acaa31b3"
   dependencies:
-    "167" "0.37.0"
-    "@motorcycle/stream" "1.6.0"
-    "@motorcycle/types" "1.5.0"
+    "@motorcycle/stream" "2.0.0"
+    "@motorcycle/types" "2.0.0"
 
-"@motorcycle/mostly-dom@3.1.0":
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/mostly-dom/-/mostly-dom-3.1.0.tgz#7a7e54d18029274342f4dd172dd714433bd9b90c"
+"@motorcycle/stream@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@motorcycle/stream/-/stream-2.0.0.tgz#dd44a14744e0f7f809b7e13f0b270f64add3e8be"
   dependencies:
-    "167" "0.37.0"
-    "@motorcycle/dom" "14.0.0"
-    "@motorcycle/stream" "1.6.0"
-    "@motorcycle/types" "1.5.0"
-    mostly-dom "4.0.0"
+    "167" "0.39.0"
+    "@most/core" "0.13.0"
+    "@most/disposable" "0.13.0"
+    "@most/scheduler" "0.13.0"
+    "@motorcycle/types" "2.0.0"
 
-"@motorcycle/run@3.5.0":
-  version "3.5.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/run/-/run-3.5.0.tgz#41fe8bcb983068132510b5850aabdcde6b2cf8e5"
+"@motorcycle/test@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@motorcycle/test/-/test-2.0.0.tgz#d5cbf55d1aac76150fe76c05d26a2fa00df47d57"
   dependencies:
-    "@motorcycle/stream" "1.6.0"
-    "@motorcycle/types" "1.5.0"
+    "@most/scheduler" "0.13.0"
+    "@motorcycle/stream" "2.0.0"
+    "@motorcycle/types" "2.0.0"
 
-"@motorcycle/stream@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/stream/-/stream-1.5.0.tgz#b1a10498ab02fbd91a4fe83544d3ab26cd1261d2"
+"@motorcycle/types@2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@motorcycle/types/-/types-2.0.0.tgz#a4adc8ecff575076312659246786c7ae705006a3"
   dependencies:
-    "167" "0.37.0"
-    "@most/core" "0.11.2"
-    "@most/disposable" "0.11.0"
-    "@most/scheduler" "0.11.0"
-    "@motorcycle/types" "1.3.0"
+    "@most/types" "0.11.1"
 
-"@motorcycle/stream@1.6.0":
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/stream/-/stream-1.6.0.tgz#ef2103414b85dcd3f329edff0884fce86ca684a5"
-  dependencies:
-    "167" "0.37.0"
-    "@most/core" "0.11.4"
-    "@most/disposable" "0.11.0"
-    "@most/scheduler" "0.11.0"
-    "@motorcycle/types" "1.5.0"
-
-"@motorcycle/test@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/test/-/test-1.5.0.tgz#caecf73acea41c84f90c0c57141461384aa4ec7b"
-  dependencies:
-    "@most/scheduler" "0.11.0"
-    "@motorcycle/stream" "1.6.0"
-    "@motorcycle/types" "1.5.0"
-
-"@motorcycle/types@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/types/-/types-1.3.0.tgz#3a895f6dd601171ea3310211328b8045badae22b"
-  dependencies:
-    "@most/types" "^0.10.0"
-
-"@motorcycle/types@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/types/-/types-1.5.0.tgz#c195204212f8ee59f25199fab9c7e17f3956dfdb"
-  dependencies:
-    "@most/types" "^0.10.0"
-
-"@types/node@8.0.25":
-  version "8.0.25"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.25.tgz#66ecaf4df93f5281b48427ee96fbcdfc4f0cdce1"
+"@types/node@8.0.28":
+  version "8.0.28"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.28.tgz#86206716f8d9251cf41692e384264cbd7058ad60"
 
 abbrev@1:
   version "1.1.0"
@@ -145,8 +112,8 @@ acorn@^4.0.3:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
 
 acorn@^5.0.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.1.tgz#53fe161111f912ab999ee887a90a0bc52822fd75"
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.1.2.tgz#911cb53e036807cf0fa778dc5d370fbd864246d7"
 
 ajv-keywords@^2.0.0:
   version "2.1.0"
@@ -373,14 +340,15 @@ brorand@^1.0.1:
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
 
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.0.6.tgz#5e7725dbdef1fd5930d4ebab48567ce451c48a0a"
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/browserify-aes/-/browserify-aes-1.0.8.tgz#c8fa3b1b7585bb7ba77c5560b60996ddec6d5309"
   dependencies:
-    buffer-xor "^1.0.2"
+    buffer-xor "^1.0.3"
     cipher-base "^1.0.0"
     create-hash "^1.1.0"
-    evp_bytestokey "^1.0.0"
+    evp_bytestokey "^1.0.3"
     inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 browserify-cipher@^1.0.0:
   version "1.0.0"
@@ -427,7 +395,7 @@ buffer-indexof@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-indexof/-/buffer-indexof-1.1.1.tgz#52fabcc6a606d1a00302802648ef68f639da268c"
 
-buffer-xor@^1.0.2:
+buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
 
@@ -600,8 +568,8 @@ content-disposition@0.5.2:
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
 
 content-type@~1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.2.tgz#b7d113aee7a8dd27bd21133c4dc2529df1721eed"
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.3.tgz#da18ef2fb64ca6acc905cc72017d3f38185b91d1"
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -703,13 +671,24 @@ decamelize@^1.0.0, decamelize@^1.1.1, decamelize@^1.1.2:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
 
-deep-equal@^1.0.1:
+deep-equal@^1.0.1, deep-equal@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
 deep-extend@~0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.4.2.tgz#48b699c27e334bf89f10892be432f6e4c7d34a7f"
+
+define-properties@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.2.tgz#83a73f2fea569898fb737193c8f873caf6d45c94"
+  dependencies:
+    foreach "^2.0.5"
+    object-keys "^1.0.8"
+
+defined@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/defined/-/defined-1.0.0.tgz#c98d9bcef75674188e110969151199e39b1fa693"
 
 del@^3.0.0:
   version "3.0.0"
@@ -829,6 +808,24 @@ error-ex@^1.2.0:
   dependencies:
     is-arrayish "^0.2.1"
 
+es-abstract@^1.5.0:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.8.2.tgz#25103263dc4decbda60e0c737ca32313518027ee"
+  dependencies:
+    es-to-primitive "^1.1.1"
+    function-bind "^1.1.1"
+    has "^1.0.1"
+    is-callable "^1.1.3"
+    is-regex "^1.0.4"
+
+es-to-primitive@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.1.1.tgz#45355248a88979034b6792e19bb81f2b7975dd0d"
+  dependencies:
+    is-callable "^1.1.1"
+    is-date-object "^1.0.1"
+    is-symbol "^1.0.1"
+
 es5-ext@^0.10.14, es5-ext@^0.10.9, es5-ext@~0.10.14:
   version "0.10.30"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.30.tgz#7141a16836697dbabfaaaeee41495ce29f52c939"
@@ -934,9 +931,9 @@ eventsource@0.1.6:
   dependencies:
     original ">=0.0.5"
 
-evp_bytestokey@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.2.tgz#f66bb88ecd57f71a766821e20283ea38c68bf80a"
+evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz#7fcbdb198dc71959432efe13842684e0525acb02"
   dependencies:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
@@ -1067,6 +1064,12 @@ find-up@^2.0.0:
   dependencies:
     locate-path "^2.0.0"
 
+for-each@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.2.tgz#2c40450b9348e97f281322593ba96704b9abd4d4"
+  dependencies:
+    is-function "~1.0.0"
+
 for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -1076,6 +1079,10 @@ for-own@^0.1.4:
   resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
   dependencies:
     for-in "^1.0.1"
+
+foreach@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/foreach/-/foreach-2.0.5.tgz#0bee005018aeb260d0a3af3ae658dd0136ec1b99"
 
 forever-agent@~0.6.1:
   version "0.6.1"
@@ -1090,8 +1097,8 @@ form-data@~2.1.1:
     mime-types "^2.1.12"
 
 forwarded@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.0.tgz#19ef9874c4ae1c297bcf078fde63a09b66a84363"
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.1.tgz#8a4e30c640b05395399a3549c730257728048961"
 
 fresh@0.5.0:
   version "0.5.0"
@@ -1124,6 +1131,10 @@ fstream@^1.0.0, fstream@^1.0.10, fstream@^1.0.2:
     inherits "~2.0.0"
     mkdirp ">=0.5 0"
     rimraf "2"
+
+function-bind@^1.0.2, function-bind@^1.1.1, function-bind@~1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
 
 gauge@~2.7.3:
   version "2.7.4"
@@ -1169,7 +1180,7 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
-glob@^7.0.3, glob@^7.0.5:
+glob@^7.0.3, glob@^7.0.5, glob@~7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.2.tgz#c19c9df9a028702d678612384a6552404c636d15"
   dependencies:
@@ -1220,6 +1231,12 @@ has-flag@^2.0.0:
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
+
+has@^1.0.1, has@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has/-/has-1.0.1.tgz#8461733f538b0837c9361e39a9ab9e9704dc2f28"
+  dependencies:
+    function-bind "^1.0.2"
 
 hash-base@^2.0.0:
   version "2.0.2"
@@ -1395,6 +1412,14 @@ is-builtin-module@^1.0.0:
   dependencies:
     builtin-modules "^1.0.0"
 
+is-callable@^1.1.1, is-callable@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.3.tgz#86eb75392805ddc33af71c92a0eedf74ee7604b2"
+
+is-date-object@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
 is-dotfile@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-dotfile/-/is-dotfile-1.0.3.tgz#a6a2f32ffd2dfb04f5ca25ecd0f6b83cf798a1e1"
@@ -1432,6 +1457,10 @@ is-fullwidth-code-point@^1.0.0:
 is-fullwidth-code-point@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz#a3b30a5c4f199183167aaab93beefae3ddfb654f"
+
+is-function@~1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-function/-/is-function-1.0.1.tgz#12cfb98b65b57dd3d193a3121f5f6e2f437602b5"
 
 is-glob@^2.0.0, is-glob@^2.0.1:
   version "2.0.1"
@@ -1481,9 +1510,19 @@ is-primitive@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-2.0.0.tgz#207bab91638499c07b2adf240a41a87210034575"
 
+is-regex@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.4.tgz#5517489b547091b0930e095654ced25ee97e9491"
+  dependencies:
+    has "^1.0.1"
+
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
+
+is-symbol@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -1720,19 +1759,15 @@ miller-rabin@^4.0.0:
     bn.js "^4.0.0"
     brorand "^1.0.1"
 
-"mime-db@>= 1.29.0 < 2":
+"mime-db@>= 1.29.0 < 2", mime-db@~1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.30.0.tgz#74c643da2dd9d6a45399963465b26d5ca7d71f01"
 
-mime-db@~1.29.0:
-  version "1.29.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.29.0.tgz#48d26d235589651704ac5916ca06001914266878"
-
 mime-types@^2.1.12, mime-types@~2.1.15, mime-types@~2.1.16, mime-types@~2.1.7:
-  version "2.1.16"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.16.tgz#2b858a52e5ecd516db897ac2be87487830698e23"
+  version "2.1.17"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.17.tgz#09d7a393f03e995a79f8af857b70a9e0ab16557a"
   dependencies:
-    mime-db "~1.29.0"
+    mime-db "~1.30.0"
 
 mime@1.3.4:
   version "1.3.4"
@@ -1764,7 +1799,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.3, minimist@^1.2.0:
+minimist@^1.1.3, minimist@^1.2.0, minimist@~1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -1774,9 +1809,9 @@ mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@~0.5.0:
   dependencies:
     minimist "0.0.8"
 
-mostly-dom@4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/mostly-dom/-/mostly-dom-4.0.0.tgz#1fff07323f03b01def2cbe6092cc94d99729049d"
+mostly-dom@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/mostly-dom/-/mostly-dom-4.3.0.tgz#6ff3188240923ae4112b68768b7b7d11661d718a"
   dependencies:
     "@most/prelude" "^1.6.0"
 
@@ -1796,8 +1831,8 @@ multicast-dns@^6.0.1:
     thunky "^0.1.0"
 
 nan@^2.3.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.6.2.tgz#e4ff34e6c95fdfb5aecc08de6596f43605a7db45"
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.7.0.tgz#d95bf721ec877e08db276ed3fc6eb78f9083ad46"
 
 negotiator@0.6.1:
   version "0.6.1"
@@ -1836,8 +1871,8 @@ node-libs-browser@^2.0.0:
     vm-browserify "0.0.4"
 
 node-pre-gyp@^0.6.36:
-  version "0.6.36"
-  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz#db604112cb74e0d477554e9b505b17abddfab786"
+  version "0.6.37"
+  resolved "https://registry.yarnpkg.com/node-pre-gyp/-/node-pre-gyp-0.6.37.tgz#3c872b236b2e266e4140578fe1ee88f693323a05"
   dependencies:
     mkdirp "^0.5.1"
     nopt "^4.0.1"
@@ -1846,6 +1881,7 @@ node-pre-gyp@^0.6.36:
     request "^2.81.0"
     rimraf "^2.6.1"
     semver "^5.3.0"
+    tape "^4.6.3"
     tar "^2.2.1"
     tar-pack "^3.4.0"
 
@@ -1897,6 +1933,14 @@ oauth-sign@~0.8.1:
 object-assign@^4.0.1, object-assign@^4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
+
+object-inspect@~1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.3.0.tgz#5b1eb8e6742e2ee83342a637034d844928ba2f6d"
+
+object-keys@^1.0.8:
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.0.11.tgz#c54601778ad560f1142ce0e01bcca8b56d13426d"
 
 object.omit@^2.0.0:
   version "2.0.1"
@@ -2019,8 +2063,8 @@ parse-json@^2.2.0:
     error-ex "^1.2.0"
 
 parseurl@~1.3.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.1.tgz#c8ab8c9223ba34888aa64a297b28853bec18da56"
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
 
 path-browserify@0.0.0:
   version "0.0.0"
@@ -2048,6 +2092,10 @@ path-key@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/path-key/-/path-key-2.0.1.tgz#411cadb574c5a140d3a4b1910d40d80cc9f40b40"
 
+path-parse@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.5.tgz#3c1adf871ea9cd6c9431b6ea2bd74a0ff055c4c1"
+
 path-to-regexp@0.1.7:
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.7.tgz#df604178005f522f15eb4490e7247a1bfaa67f8c"
@@ -2067,8 +2115,8 @@ path-type@^2.0.0:
     pify "^2.0.0"
 
 pbkdf2@^3.0.3:
-  version "3.0.13"
-  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.13.tgz#c37d295531e786b1da3e3eadc840426accb0ae25"
+  version "3.0.14"
+  resolved "https://registry.yarnpkg.com/pbkdf2/-/pbkdf2-3.0.14.tgz#a35e13c64799b06ce15320f459c230e68e73bade"
   dependencies:
     create-hash "^1.1.2"
     create-hmac "^1.1.4"
@@ -2260,11 +2308,10 @@ redent@^1.0.0:
     strip-indent "^1.0.1"
 
 regex-cache@^0.4.2:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.3.tgz#9b1a6c35d4d0dfcef5711ae651e8e9d3d7114145"
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/regex-cache/-/regex-cache-0.4.4.tgz#75bdc58a2a1496cec48a12835bc54c8d562336dd"
   dependencies:
     is-equal-shallow "^0.1.3"
-    is-primitive "^2.0.0"
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -2323,6 +2370,18 @@ requires-port@1.0.x, requires-port@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
+resolve@~1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"
+  dependencies:
+    path-parse "^1.0.5"
+
+resumer@~0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/resumer/-/resumer-0.0.0.tgz#f1e8f461e4064ba39e82af3cdc2a8c893d076759"
+  dependencies:
+    through "~2.3.4"
+
 right-align@^0.1.1:
   version "0.1.3"
   resolved "https://registry.yarnpkg.com/right-align/-/right-align-0.1.3.tgz#61339b722fe6a3515689210d24e14c96148613ef"
@@ -2330,8 +2389,8 @@ right-align@^0.1.1:
     align-text "^0.1.1"
 
 rimraf@2, rimraf@^2.2.8, rimraf@^2.5.1, rimraf@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.1.tgz#c2338ec643df7a1b7fe5c54fa86f57428a55f33d"
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:
     glob "^7.0.5"
 
@@ -2554,6 +2613,14 @@ string-width@^2.0.0:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string.prototype.trim@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trim/-/string.prototype.trim-1.1.2.tgz#d04de2c89e137f4d7d206f086b5ed2fae6be8cea"
+  dependencies:
+    define-properties "^1.1.2"
+    es-abstract "^1.5.0"
+    function-bind "^1.0.2"
+
 string_decoder@^0.10.25:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -2611,14 +2678,32 @@ supports-color@^3.1.1:
     has-flag "^1.0.0"
 
 supports-color@^4.0.0, supports-color@^4.2.1:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.2.1.tgz#65a4bb2631e90e02420dba5554c375a4754bb836"
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.4.0.tgz#883f7ddabc165142b2a61427f3352ded195d1a3e"
   dependencies:
     has-flag "^2.0.0"
 
 tapable@^0.2.7:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.8.tgz#99372a5c999bf2df160afc0d74bed4f47948cd22"
+
+tape@^4.6.3:
+  version "4.8.0"
+  resolved "https://registry.yarnpkg.com/tape/-/tape-4.8.0.tgz#f6a9fec41cc50a1de50fa33603ab580991f6068e"
+  dependencies:
+    deep-equal "~1.0.1"
+    defined "~1.0.0"
+    for-each "~0.3.2"
+    function-bind "~1.1.0"
+    glob "~7.1.2"
+    has "~1.0.1"
+    inherits "~2.0.3"
+    minimist "~1.2.0"
+    object-inspect "~1.3.0"
+    resolve "~1.4.0"
+    resumer "~0.0.0"
+    string.prototype.trim "~1.1.2"
+    through "~2.3.8"
 
 tar-pack@^3.4.0:
   version "3.4.0"
@@ -2640,6 +2725,10 @@ tar@^2.2.1:
     block-stream "*"
     fstream "^1.0.2"
     inherits "2"
+
+through@~2.3.4, through@~2.3.8:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
 
 thunky@^0.1.0:
   version "0.1.0"
@@ -2669,9 +2758,9 @@ trim-newlines@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-1.0.0.tgz#5887966bb582a4503a41eb524f7d35011815a613"
 
-ts-loader@2.3.4:
-  version "2.3.4"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-2.3.4.tgz#904f82f6812406f3f073c1c114eea2759e27f80a"
+ts-loader@2.3.7:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-2.3.7.tgz#a9028ced473bee12f28a75f9c5b139979d33f2fc"
   dependencies:
     chalk "^2.0.1"
     enhanced-resolve "^3.0.0"
@@ -2855,9 +2944,9 @@ webpack-sources@^1.0.1:
     source-list-map "^2.0.0"
     source-map "~0.5.3"
 
-webpack@3.5.5:
-  version "3.5.5"
-  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.5.5.tgz#3226f09fc8b3e435ff781e7af34f82b68b26996c"
+webpack@3.5.6:
+  version "3.5.6"
+  resolved "https://registry.yarnpkg.com/webpack/-/webpack-3.5.6.tgz#a492fb6c1ed7f573816f90e00c8fbb5a20cc5c36"
   dependencies:
     acorn "^5.0.0"
     acorn-dynamic-import "^2.0.0"
@@ -2889,8 +2978,8 @@ websocket-driver@>=0.5.1:
     websocket-extensions ">=0.1.1"
 
 websocket-extensions@>=0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.1.tgz#76899499c184b6ef754377c2dbb0cd6cb55d29e7"
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.2.tgz#0e18781de629a18308ce1481650f67ffa2693a5d"
 
 which-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
I've hand-tested all of the examples to ensure they work correctly with upgraded dependencies. 
First by removing `node_modules` and deleting the `yarn.lock` in each example folder first, then upgrading the dependencies and running `yarn` to rebuild the `yarn.lock`.