### PR TITLE
Chore/upgrade dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,10 +12,10 @@
     "dox": "0.9.0",
     "glob-expand": "0.2.1",
     "husky": "0.14.3",
-    "lerna": "2.1.2",
-    "lint-staged": "4.1.3",
-    "prettier": "1.6.1",
-    "typescript": "2.5.2"
+    "lerna": "2.3.1",
+    "lint-staged": "4.2.3",
+    "prettier": "1.7.4",
+    "typescript": "2.5.3"
   },
   "lint-staged": {
     "*.ts": [

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dox": "0.9.0",
     "glob-expand": "0.2.1",
     "husky": "0.14.3",
-    "lerna": "2.3.1",
+    "lerna": "2.4.0",
     "lint-staged": "4.2.3",
     "prettier": "1.7.4",
     "typescript": "2.5.3"

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/motorcyclets/motorcycle#readme",
   "dependencies": {
-    "167": "0.39.0",
+    "167": "0.42.0",
     "@motorcycle/stream": "2.1.0",
     "@motorcycle/types": "2.1.0"
   },

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -36,7 +36,7 @@
   },
   "homepage": "https://github.com/motorcyclets/motorcycle#readme",
   "dependencies": {
-    "167": "0.42.0",
+    "167": "0.43.0",
     "@motorcycle/stream": "2.1.0",
     "@motorcycle/types": "2.1.0"
   },

--- a/packages/mostly-dom/package.json
+++ b/packages/mostly-dom/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/motorcyclets/motorcycle#readme",
   "dependencies": {
-    "167": "0.39.0",
+    "167": "0.42.0",
     "@motorcycle/dom": "16.1.0",
     "@motorcycle/stream": "2.1.0",
     "@motorcycle/types": "2.1.0",

--- a/packages/mostly-dom/package.json
+++ b/packages/mostly-dom/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/motorcyclets/motorcycle#readme",
   "dependencies": {
-    "167": "0.42.0",
+    "167": "0.43.0",
     "@motorcycle/dom": "16.1.0",
     "@motorcycle/stream": "2.1.0",
     "@motorcycle/types": "2.1.0",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -41,5 +41,8 @@
     "@most/prelude": "1.6.4",
     "@most/scheduler": "0.13.0",
     "@motorcycle/types": "2.1.0"
+  },
+  "devDependencies": {
+    "@typed/assertions": "1.1.0"
   }
 }

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/motorcyclets/motorcycle#readme",
   "dependencies": {
-    "167": "0.39.0",
+    "167": "0.42.0",
     "@most/core": "0.13.0",
     "@most/disposable": "0.13.0",
     "@most/scheduler": "0.13.0",

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -38,6 +38,7 @@
     "167": "0.42.0",
     "@most/core": "0.13.0",
     "@most/disposable": "0.13.0",
+    "@most/prelude": "1.6.4",
     "@most/scheduler": "0.13.0",
     "@motorcycle/types": "2.1.0"
   }

--- a/packages/stream/package.json
+++ b/packages/stream/package.json
@@ -35,11 +35,11 @@
   },
   "homepage": "https://github.com/motorcyclets/motorcycle#readme",
   "dependencies": {
-    "167": "0.42.0",
-    "@most/core": "0.13.0",
-    "@most/disposable": "0.13.0",
+    "167": "0.43.0",
+    "@most/core": "0.14.0",
+    "@most/disposable": "0.13.1",
     "@most/prelude": "1.6.4",
-    "@most/scheduler": "0.13.0",
+    "@most/scheduler": "0.13.1",
     "@motorcycle/types": "2.1.0"
   },
   "devDependencies": {

--- a/packages/stream/yarn.lock
+++ b/packages/stream/yarn.lock
@@ -2,9 +2,17 @@
 # yarn lockfile v1
 
 
+"167@0.36.0":
+  version "0.36.0"
+  resolved "https://registry.yarnpkg.com/167/-/167-0.36.0.tgz#040850b3b60fda4fe1b6305676bd42dc0ffe3dae"
+
 "167@0.42.0":
   version "0.42.0"
   resolved "https://registry.yarnpkg.com/167/-/167-0.42.0.tgz#872a7348b46215e70fd6a6a6f8a19745a379cdde"
+
+"167@^0.30.0":
+  version "0.30.0"
+  resolved "https://registry.yarnpkg.com/167/-/167-0.30.0.tgz#8e571e64851bebe8dced5723b48a07ab297b5b9b"
 
 "@most/core@0.13.0":
   version "0.13.0"
@@ -42,3 +50,26 @@
   resolved "https://registry.yarnpkg.com/@motorcycle/types/-/types-2.1.0.tgz#0af595e60bf21bbe55953a04d3801d6223cb66cc"
   dependencies:
     "@most/types" "0.11.1"
+
+"@typed/assertions@1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@typed/assertions/-/assertions-1.1.0.tgz#6428276e542b213356b82da3152ee4dd5d7ec22c"
+  dependencies:
+    "167" "0.36.0"
+    assertion-error-diff "^1.0.0"
+
+assertion-error-diff@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/assertion-error-diff/-/assertion-error-diff-1.0.0.tgz#5462fe1ff70849bfec25d108aecee5d95b86d8e5"
+  dependencies:
+    "167" "^0.30.0"
+    typed-colors "^1.0.0"
+    typed-figures "^1.0.0"
+
+typed-colors@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/typed-colors/-/typed-colors-1.0.0.tgz#a86fb57183ea8d955d811aec0e100f565e48bbb9"
+
+typed-figures@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/typed-figures/-/typed-figures-1.0.0.tgz#898932b2797b59532cfdf03f23ec2e2dc136126a"

--- a/packages/stream/yarn.lock
+++ b/packages/stream/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"167@0.39.0":
-  version "0.39.0"
-  resolved "https://registry.yarnpkg.com/167/-/167-0.39.0.tgz#79638b8019aa92cf500eb43f6ed04eef65f8d987"
+"167@0.42.0":
+  version "0.42.0"
+  resolved "https://registry.yarnpkg.com/167/-/167-0.42.0.tgz#872a7348b46215e70fd6a6a6f8a19745a379cdde"
 
 "@most/core@0.13.0":
   version "0.13.0"
@@ -22,7 +22,7 @@
     "@most/prelude" "^1.6.4"
     "@most/types" "^0.11.1"
 
-"@most/prelude@^1.6.4":
+"@most/prelude@1.6.4", "@most/prelude@^1.6.4":
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/@most/prelude/-/prelude-1.6.4.tgz#254ab6e22c0d4e7cb19e6ec1c966b75f57317f25"
 
@@ -37,8 +37,8 @@
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/@most/types/-/types-0.11.1.tgz#5e305e0e346c5b01f1ebdeec4c1dfa5b189b5f9d"
 
-"@motorcycle/types@2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@motorcycle/types/-/types-2.0.0.tgz#a4adc8ecff575076312659246786c7ae705006a3"
+"@motorcycle/types@2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@motorcycle/types/-/types-2.1.0.tgz#0af595e60bf21bbe55953a04d3801d6223cb66cc"
   dependencies:
     "@most/types" "0.11.1"

--- a/packages/test/package.json
+++ b/packages/test/package.json
@@ -34,11 +34,11 @@
   },
   "homepage": "https://github.com/motorcyclets/motorcycle#readme",
   "dependencies": {
-    "@most/scheduler": "0.13.0",
+    "@most/scheduler": "0.13.1",
     "@motorcycle/stream": "2.1.0",
     "@motorcycle/types": "2.1.0"
   },
   "devDependencies": {
-    "@most/core": "0.13.0"
+    "@most/core": "0.14.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -81,7 +81,7 @@ ansi-escapes@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-2.0.0.tgz#5bae52be424878dd9783e8910e3fc2922e83c81b"
 
-ansi-regex@^2.0.0, ansi-regex@^2.1.1:
+ansi-regex@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-2.1.1.tgz#c3b33ab5ee360d86e0e628f0468ae7ef27d654df"
 
@@ -93,7 +93,7 @@ ansi-styles@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
 
-ansi-styles@^3.0.0, ansi-styles@^3.1.0:
+ansi-styles@^3.1.0, ansi-styles@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.0.tgz#c159b8d5be0f9e5a6f346dab94f16ce022161b88"
   dependencies:
@@ -1553,21 +1553,18 @@ james-browser-launcher@1.3.1:
     rimraf "~2.6.1"
     win-detect-browsers "1.0.2"
 
-jest-matcher-utils@^20.0.3:
-  version "20.0.3"
-  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-20.0.3.tgz#b3a6b8e37ca577803b0832a98b164f44b7815612"
-  dependencies:
-    chalk "^1.1.3"
-    pretty-format "^20.0.3"
+jest-get-type@^21.2.0:
+  version "21.2.0"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-21.2.0.tgz#f6376ab9db4b60d81e39f30749c6c466f40d4a23"
 
-jest-validate@^20.0.3:
-  version "20.0.3"
-  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-20.0.3.tgz#d0cfd1de4f579f298484925c280f8f1d94ec3cab"
+jest-validate@^21.1.0:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/jest-validate/-/jest-validate-21.2.1.tgz#cc0cbca653cd54937ba4f2a111796774530dd3c7"
   dependencies:
-    chalk "^1.1.3"
-    jest-matcher-utils "^20.0.3"
+    chalk "^2.0.1"
+    jest-get-type "^21.2.0"
     leven "^2.1.0"
-    pretty-format "^20.0.3"
+    pretty-format "^21.2.1"
 
 js-yaml@^3.4.3:
   version "3.10.0"
@@ -1634,9 +1631,9 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-lerna@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/lerna/-/lerna-2.1.2.tgz#b07eb7a4d7dd7d44a105262fef49b2229301c577"
+lerna@2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/lerna/-/lerna-2.3.1.tgz#16397bc8ad8703381c8435e42ae0cd02086e8ee3"
   dependencies:
     async "^1.5.0"
     chalk "^2.1.0"
@@ -1691,16 +1688,16 @@ linkify-it@^2.0.0:
   dependencies:
     uc.micro "^1.0.1"
 
-lint-staged@4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-4.1.3.tgz#07c592e4b8dee914450a183c761187dc53d079e2"
+lint-staged@4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-4.2.3.tgz#5a1f12256af06110b96225f109dbf215009a37a9"
   dependencies:
     app-root-path "^2.0.0"
     chalk "^2.1.0"
     cosmiconfig "^1.1.0"
     execa "^0.8.0"
     is-glob "^4.0.0"
-    jest-validate "^20.0.3"
+    jest-validate "^21.1.0"
     listr "^0.12.0"
     lodash "^4.17.4"
     log-symbols "^2.0.0"
@@ -2302,16 +2299,16 @@ plist@^2.0.1:
     xmlbuilder "8.2.2"
     xmldom "0.1.x"
 
-prettier@1.6.1:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.6.1.tgz#850f411a3116226193e32ea5acfc21c0f9a76d7d"
+prettier@1.7.4:
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.7.4.tgz#5e8624ae9363c80f95ec644584ecdf55d74f93fa"
 
-pretty-format@^20.0.3:
-  version "20.0.3"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-20.0.3.tgz#020e350a560a1fe1a98dc3beb6ccffb386de8b14"
+pretty-format@^21.2.1:
+  version "21.2.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-21.2.1.tgz#ae5407f3cf21066cd011aa1ba5fce7b6a2eddb36"
   dependencies:
-    ansi-regex "^2.1.1"
-    ansi-styles "^3.0.0"
+    ansi-regex "^3.0.0"
+    ansi-styles "^3.2.0"
 
 process-nextick-args@~1.0.6:
   version "1.0.7"
@@ -2916,9 +2913,9 @@ typedarray@^0.0.6, typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@2.5.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.2.tgz#038a95f7d9bbb420b1bf35ba31d4c5c1dd3ffe34"
+typescript@2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
 
 uc.micro@^1.0.1:
   version "1.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -353,8 +353,8 @@ buffer-xor@^1.0.3:
   resolved "https://registry.yarnpkg.com/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
 
 buffer@^5.0.2:
-  version "5.0.7"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.0.7.tgz#570a290b625cf2603290c1149223d27ccf04db97"
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.0.8.tgz#84daa52e7cf2fa8ce4195bc5cf0f7809e0930b24"
   dependencies:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
@@ -578,8 +578,8 @@ content-disposition@0.5.2:
   resolved "https://registry.yarnpkg.com/content-disposition/-/content-disposition-0.5.2.tgz#0cf68bb9ddf5f2be7961c3a85178cb85dba78cb4"
 
 content-type@~1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.3.tgz#da18ef2fb64ca6acc905cc72017d3f38185b91d1"
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
 
 conventional-changelog-angular@^1.5.0:
   version "1.5.0"
@@ -838,7 +838,13 @@ debug@2.6.7:
   dependencies:
     ms "2.0.0"
 
-debug@2.6.8, debug@^2.1.0:
+debug@2.6.9:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
+  dependencies:
+    ms "2.0.0"
+
+debug@^2.1.0:
   version "2.6.8"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.8.tgz#e731531ca2ede27d188222427da17821d68ff4fc"
   dependencies:
@@ -984,8 +990,8 @@ esprima@^4.0.0:
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.0.tgz#4499eddcd1110e0b218bacf2fa7f7f59f55ca804"
 
 etag@~1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.0.tgz#6f631aef336d6c46362b51764044ce216be3c051"
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
 
 events@~1.1.0:
   version "1.1.1"
@@ -1081,14 +1087,14 @@ figures@^2.0.0:
     escape-string-regexp "^1.0.5"
 
 finalhandler@~1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.4.tgz#18574f2e7c4b98b8ae3b230c21f201f31bdb3fb7"
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.0.6.tgz#007aea33d1a4d3e42017f624848ad58d212f814f"
   dependencies:
-    debug "2.6.8"
+    debug "2.6.9"
     encodeurl "~1.0.1"
     escape-html "~1.0.3"
     on-finished "~2.3.0"
-    parseurl "~1.3.1"
+    parseurl "~1.3.2"
     statuses "~1.3.1"
     unpipe "~1.0.0"
 
@@ -1106,8 +1112,8 @@ find-up@^2.0.0, find-up@^2.1.0:
     locate-path "^2.0.0"
 
 forwarded@~0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.1.tgz#8a4e30c640b05395399a3549c730257728048961"
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.1.2.tgz#98c23dab1175657b8c0573e8ceccd91b0ff18c84"
 
 fresh@0.5.0:
   version "0.5.0"
@@ -1316,7 +1322,7 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hosted-git-info@^2.1.4:
+hosted-git-info@^2.1.4, hosted-git-info@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.5.0.tgz#6d60e34b3abbc8313062c3b798ef8d901a07af3c"
 
@@ -1631,9 +1637,9 @@ lcid@^1.0.0:
   dependencies:
     invert-kv "^1.0.0"
 
-lerna@2.3.1:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/lerna/-/lerna-2.3.1.tgz#16397bc8ad8703381c8435e42ae0cd02086e8ee3"
+lerna@2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/lerna/-/lerna-2.4.0.tgz#7b76446b154bafb9cba8996f3dc233f1cb6ca7c3"
   dependencies:
     async "^1.5.0"
     chalk "^2.1.0"
@@ -1651,6 +1657,7 @@ lerna@2.3.1:
     glob-parent "^3.1.0"
     globby "^6.1.0"
     graceful-fs "^4.1.11"
+    hosted-git-info "^2.5.0"
     inquirer "^3.2.2"
     is-ci "^1.0.10"
     load-json-file "^3.0.0"
@@ -2211,7 +2218,7 @@ parse-json@^3.0.0:
   dependencies:
     error-ex "^1.3.1"
 
-parseurl@~1.3.1:
+parseurl@~1.3.1, parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
 
@@ -2589,11 +2596,18 @@ setprototypeof@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/setprototypeof/-/setprototypeof-1.0.3.tgz#66567e37043eeb4f04d91bd658c0cbefb55b8e04"
 
-sha.js@^2.4.0, sha.js@^2.4.8, sha.js@~2.4.4:
+sha.js@^2.4.0, sha.js@^2.4.8:
   version "2.4.8"
   resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.8.tgz#37068c2c476b6baf402d14a49c67f597921f634f"
   dependencies:
     inherits "^2.0.1"
+
+sha.js@~2.4.4:
+  version "2.4.9"
+  resolved "https://registry.yarnpkg.com/sha.js/-/sha.js-2.4.9.tgz#98f64880474b74f4a38b8da9d3c0f2d104633e7d"
+  dependencies:
+    inherits "^2.0.1"
+    safe-buffer "^5.0.1"
 
 shasum@^1.0.0:
   version "1.0.2"
@@ -2987,8 +3001,8 @@ validate-npm-package-license@^3.0.1:
     spdx-expression-parse "~1.0.0"
 
 vary@~1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.1.tgz#67535ebb694c1d52257457984665323f587e8d37"
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"
 
 vm-browserify@~0.0.1:
   version "0.0.4"


### PR DESCRIPTION
- Upgrade dependencies.
- Add missing module `@most/prelude` to `@motorcycle/stream`.
- Add missing dev module `@typed/assertions` to `@motorcycle/stream`

This PR also includes a new _yarn.lock_ file to reflect the dependency upgrades.